### PR TITLE
Update RecordDisplay.jsp

### DIFF
--- a/MassBank-Project/MassBank-web/src/main/webapp/RecordDisplay.jsp
+++ b/MassBank-Project/MassBank-web/src/main/webapp/RecordDisplay.jsp
@@ -97,7 +97,7 @@ ${structureddata}
 			<div class="w3-row">
 				<div class="w3-twothird w3-text-grey w3-small">
 					<a
-						href="https://metabolomics-usi.gnps2.org/spectrum/?usi=mzspec:MASSBANK::accession:MSBNK-AAFC-AC000372/spectrum/?usi=mzspec:MASSBANK::accession:${accession}"
+						href="https://metabolomics-usi.gnps2.org/spectrum/?usi=mzspec:MASSBANK::accession:${accession}"
 						target="_blank">metabolomics-usi visualisation</a>
 				</div>
 			</div>


### PR DESCRIPTION
Removing unneeded part of the usi.

Additional comment:
It seems that underscores `_` break the visualization using <https://metabolomics-usi.gnps2.org>. (see <https://massbank.eu/MassBank/RecordDisplay?id=MSBNK-BGC_Munich-RP000611> or <https://massbank.eu/MassBank/RecordDisplay?id=MSBNK-Keio_Univ-KO001261> in comparison to <https://massbank.eu/MassBank/RecordDisplay?id=MSBNK-RIKEN-PR100496> (no underscore).

Also tagging @mwang87